### PR TITLE
manifest: Track our bison fork

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -67,7 +67,7 @@
   <project path="external/archive-patcher" name="platform/external/archive-patcher" groups="pdk" remote="aosp" />
   <project path="external/autotest" name="platform/external/autotest" groups="pdk-fs" remote="aosp" />
   <project path="external/avahi" name="platform/external/avahi" groups="pdk" remote="aosp" />
-  <project path="external/bison" name="platform/external/bison" groups="pdk" remote="aosp" />
+  <project path="external/bison" name="LineageOS/android_external_bison" groups="pdk" />
   <project path="external/blktrace" name="platform/external/blktrace" groups="pdk" remote="aosp" />
   <project path="external/boringssl" name="LineageOS/android_external_boringssl" groups="pdk" />
   <project path="external/bouncycastle" name="platform/external/bouncycastle" groups="pdk" remote="aosp" />


### PR DESCRIPTION
Our repository contains a critical fix for MacOS 10.13
(High Sierra).

Change-Id: I76512edff010588a70a1b0ff937e7490f7cd1061